### PR TITLE
Change worker naming approch from os.pid to custom worker_<age>_<time…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+explore
+trace.json
+
 # C extensions
 *.so
 example*

--- a/example/README.md
+++ b/example/README.md
@@ -22,7 +22,7 @@ chmod 777 /tmp/metrics_test
 
 # 2) Set env vars
 export PROMETHEUS_MULTIPROC_DIR=/tmp/metrics_test
-export PROMETHEUS_METRICS_PORT=9090
+export PROMETHEUS_METRICS_PORT=9091
 
 # 3) Start Gunicorn (uses your gunicorn.conf.py)
 gunicorn --config gunicorn.conf.py app:app 
@@ -55,7 +55,7 @@ scrape_configs:
   - job_name: 'gunicorn-prometheus-exporter'         
     metrics_path: '/metrics'       
     static_configs:
-      - targets: ['127.0.0.1:9090'] # our example exporter
+      - targets: ['127.0.0.1:9091'] # our example exporter
 ```
 
 2. Run Prometheus using Docker:

--- a/example/gunicorn.conf.py
+++ b/example/gunicorn.conf.py
@@ -24,7 +24,7 @@ def when_ready(server):
         logging.warning("PROMETHEUS_MULTIPROC_DIR not set; skipping metrics server")
         return
 
-    port = int(os.environ.get("PROMETHEUS_METRICS_PORT", 9090))
+    port = int(os.environ.get("PROMETHEUS_METRICS_PORT", 9091))
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
     logger.info(f"Starting Prometheus multiprocess metrics server on :{port}")

--- a/example/gunicorn.conf.py
+++ b/example/gunicorn.conf.py
@@ -8,11 +8,12 @@ This configuration:
 - Exports metrics on port 9090 at /metrics endpoint, aggregating across all workers
 """
 
-import os
 import logging
+import os
 
 import gunicorn.arbiter
-from prometheus_client import start_http_server, CollectorRegistry, multiprocess
+from prometheus_client import CollectorRegistry, multiprocess, start_http_server
+
 
 # —————————————————————————————————————————————————————————————————————————————
 # Hook to start a multiprocess‐aware Prometheus metrics server when Gunicorn is ready

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,6 @@ classifiers = [
     "Intended Audience :: Developers",
     # License classifier removed per Flit requirements
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/src/gunicorn_prometheus_exporter/metrics.py
+++ b/src/gunicorn_prometheus_exporter/metrics.py
@@ -83,17 +83,17 @@ class BaseMetric(metaclass=MetricMeta):
         """Get metric samples."""
         return cls._metric._samples()
 
-    @property
+    @classmethod
     def _name(cls):
         """Get metric name."""
         return cls._metric._name
 
-    @property
+    @classmethod
     def _documentation(cls):
         """Get metric documentation."""
         return cls._metric._documentation
 
-    @property
+    @classmethod
     def _labelnames(cls):
         """Get metric label names."""
         return cls._metric._labelnames

--- a/src/gunicorn_prometheus_exporter/plugin.py
+++ b/src/gunicorn_prometheus_exporter/plugin.py
@@ -40,10 +40,10 @@ class PrometheusWorker(SyncWorker):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.start_time = time.time()
+        self.start_time = int(time.time())
         # Create a unique worker ID using worker age and timestamp
         # Format: worker_<age>_<timestamp>
-        self.worker_id = f"worker_{self.age}_{int(self.start_time)}"
+        self.worker_id = f"worker_{self.age}_{self.start_time}"
         self.process = psutil.Process()
         logger.info(f"PrometheusWorker initialized with ID: {self.worker_id}")
 

--- a/src/gunicorn_prometheus_exporter/plugin.py
+++ b/src/gunicorn_prometheus_exporter/plugin.py
@@ -40,10 +40,10 @@ class PrometheusWorker(SyncWorker):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.start_time = int(time.time())
+        self.start_time = time.time()
         # Create a unique worker ID using worker age and timestamp
         # Format: worker_<age>_<timestamp>
-        self.worker_id = f"worker_{self.age}_{self.start_time}"
+        self.worker_id = f"worker_{self.age}_{int(self.start_time)}"
         self.process = psutil.Process()
         logger.info(f"PrometheusWorker initialized with ID: {self.worker_id}")
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -232,9 +232,8 @@ def test_clear_old_metrics(worker):
     WORKER_MEMORY.set(1000, worker_id=old_worker_id)
 
     # Add some new format metrics
-    new_worker_id = f"worker_{worker.age}_{int(worker.start_time)}"
-    WORKER_REQUESTS.inc(worker_id=new_worker_id)
-    WORKER_MEMORY.set(2000, worker_id=new_worker_id)
+    WORKER_REQUESTS.inc(worker_id=worker.worker_id)
+    WORKER_MEMORY.set(2000, worker_id=worker.worker_id)
 
     # Clear old metrics
     worker._clear_old_metrics()
@@ -242,8 +241,8 @@ def test_clear_old_metrics(worker):
     # Check that old metrics are gone but new ones remain
     samples = list(WORKER_REQUESTS.collect())
     assert len(samples) == 1
-    assert samples[0].samples[0].labels["worker_id"] == new_worker_id
+    assert samples[0].samples[0].labels["worker_id"] == str(worker.worker_id)
 
     samples = list(WORKER_MEMORY.collect())
     assert len(samples) == 1
-    assert samples[0].samples[0].labels["worker_id"] == new_worker_id
+    assert samples[0].samples[0].labels["worker_id"] == str(worker.worker_id)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, py311, py312, py313
+envlist = py310, py311, py312, py313
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
…stamp>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced documentation with detailed instructions for Prometheus integration, metric labels, worker ID format, and example PromQL queries.
  - Updated example documentation to reflect metrics server port change and added Prometheus UI setup guidance.
- **Bug Fixes**
  - Updated worker ID format for improved lifecycle tracking and metric consistency.
  - Implemented automatic cleanup of old metrics associated with outdated worker IDs.
- **Tests**
  - Improved and expanded test coverage for new worker ID format and metric cleanup functionality.
- **Chores**
  - Updated ignored files in version control configuration.
  - Removed support for Python 3.8 and 3.9 in testing and project metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->