### PR TITLE
Fix TTIN docstring wording

### DIFF
--- a/src/gunicorn_prometheus_exporter/master.py
+++ b/src/gunicorn_prometheus_exporter/master.py
@@ -46,8 +46,8 @@ class PrometheusMaster(Arbiter):
         super().handle_hup()
 
     def handle_ttin(self):
-        """Handle TTI signal."""
-        logger.info("Gunicorn master TTI signal received")
+        """Handle TTIN signal."""
+        logger.info("Gunicorn master TTIN signal received")
         MasterWorkerRestarts.labels(reason="ttin").inc()
         super().handle_ttin()
 


### PR DESCRIPTION
## Summary
- clarify TTIN docstring and log message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*
- `pip install -q '.[dev]'` *(fails: Could not find a version that satisfies the requirement flit_core<4,>=3.7)*

------
https://chatgpt.com/codex/tasks/task_e_6884c6599a20832b8e068237e3531c42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected docstring and log message to accurately reference the TTIN signal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->