### PR TITLE
Fix README example config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ pip install gunicorn-prometheus-exporter
 ### 2. Basic Usage
 
 Create a Gunicorn config file (`gunicorn.conf.py`):
-See `./example/gunicorn.conf.py` for a complete working example.
+See `./example/gunicorn_simple.conf.py` for a complete working example.
 
 ### 3. Start Gunicorn
 


### PR DESCRIPTION
## Summary
- reference correct sample config in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_6884c655f57c832b97979ca09f5bce3a