### PR TITLE
Fix stale worker metrics cleanup

### DIFF
--- a/src/gunicorn_prometheus_exporter/plugin.py
+++ b/src/gunicorn_prometheus_exporter/plugin.py
@@ -70,6 +70,10 @@ class PrometheusWorker(SyncWorker):
         # Format: worker_<age>_<timestamp>
         self.worker_id = f"worker_{self.age}_{int(self.start_time)}"
         self.process = psutil.Process()
+        # Remove any lingering metrics from previous worker instances
+        # that used PID-based identifiers. This prevents metric bloat
+        # when workers are restarted (e.g. via TTIN/USR2).
+        self._clear_old_metrics()
         # Initialize request counter
         self._request_count = 0
 


### PR DESCRIPTION
## Summary
- clear stale worker metrics on initialization

## Testing
- `pre-commit` *(fails: couldn't install deps)*
- `pytest` *(fails: couldn't install deps)*

------
https://chatgpt.com/codex/tasks/task_e_6884c87ed2c8832b832f2db2498457a9