### PR TITLE
Replace print with logging

### DIFF
--- a/src/gunicorn_prometheus_exporter/__init__.py
+++ b/src/gunicorn_prometheus_exporter/__init__.py
@@ -71,6 +71,8 @@ THE SOLUTION:
 - This ensures our PrometheusMaster is always used regardless of import paths
 """
 
+import logging
+
 import gunicorn.app.base
 import gunicorn.arbiter
 
@@ -79,6 +81,9 @@ from .forwarder import RedisForwarder, get_forwarder_manager
 from .master import PrometheusMaster
 from .metrics import registry
 from .plugin import PrometheusWorker
+
+
+logger = logging.getLogger(__name__)
 
 
 # Force Arbiter replacement before gunicorn starts
@@ -136,15 +141,16 @@ def start_redis_forwarder():
 
         # Start it
         if manager.start_forwarder("redis"):
-            print(
-                f"Redis forwarder started (interval: {config.redis_forward_interval}s)"
+            logger.info(
+                "Redis forwarder started (interval: %ss)",
+                config.redis_forward_interval,
             )
             return True
 
-        print("Failed to start Redis forwarder")
+        logger.error("Failed to start Redis forwarder")
         return False
     except Exception as e:
-        print(f"Failed to start Redis forwarder: {e}")
+        logger.error("Failed to start Redis forwarder: %s", e)
         return False
 
 

--- a/src/gunicorn_prometheus_exporter/config.py
+++ b/src/gunicorn_prometheus_exporter/config.py
@@ -1,6 +1,10 @@
 """Configuration management for Gunicorn Prometheus Exporter."""
 
+import logging
 import os
+
+
+logger = logging.getLogger(__name__)
 
 
 class ExporterConfig:
@@ -47,9 +51,9 @@ class ExporterConfig:
     def _setup_multiproc_dir(self):
         """Set up the Prometheus multiprocess directory."""
         if not os.environ.get(self.ENV_PROMETHEUS_MULTIPROC_DIR):
-            os.environ[
-                self.ENV_PROMETHEUS_MULTIPROC_DIR
-            ] = self.PROMETHEUS_MULTIPROC_DIR
+            os.environ[self.ENV_PROMETHEUS_MULTIPROC_DIR] = (
+                self.PROMETHEUS_MULTIPROC_DIR
+            )
 
     @property
     def prometheus_multiproc_dir(self) -> str:
@@ -202,13 +206,13 @@ class ExporterConfig:
                     missing_vars.append(f"{var_name} ({description})")
 
             if missing_vars:
-                print("Required environment variables not set:")
+                logger.error("Required environment variables not set:")
                 for var in missing_vars:
-                    print(f"   - {var}")
-                print("\n Set these variables before running in production:")
-                print(f"   export {self.ENV_PROMETHEUS_BIND_ADDRESS}=0.0.0.0")
-                print(f"   export {self.ENV_PROMETHEUS_METRICS_PORT}=9091")
-                print(f"   export {self.ENV_GUNICORN_WORKERS}=4")
+                    logger.error("   - %s", var)
+                logger.error("\n Set these variables before running in production:")
+                logger.error("   export %s=0.0.0.0", self.ENV_PROMETHEUS_BIND_ADDRESS)
+                logger.error("   export %s=9091", self.ENV_PROMETHEUS_METRICS_PORT)
+                logger.error("   export %s=4", self.ENV_GUNICORN_WORKERS)
                 return False
 
             # Validate multiprocess directory
@@ -237,20 +241,20 @@ class ExporterConfig:
             return True
 
         except Exception as e:
-            print(f"Configuration validation failed: {e}")
+            logger.error("Configuration validation failed: %s", e)
             return False
 
     def print_config(self):
-        """Print current configuration."""
-        print("Gunicorn Prometheus Exporter Configuration:")
-        print("=" * 50)
-        print(f"Prometheus Multiproc Dir: {self.prometheus_multiproc_dir}")
-        print(f"Prometheus Metrics Port: {self.prometheus_metrics_port}")
-        print(f"Prometheus Bind Address: {self.prometheus_bind_address}")
-        print(f"Gunicorn Workers: {self.gunicorn_workers}")
-        print(f"Gunicorn Timeout: {self.gunicorn_timeout}")
-        print(f"Gunicorn Keepalive: {self.gunicorn_keepalive}")
-        print("=" * 50)
+        """Log the current configuration."""
+        logger.info("Gunicorn Prometheus Exporter Configuration:")
+        logger.info("=" * 50)
+        logger.info("Prometheus Multiproc Dir: %s", self.prometheus_multiproc_dir)
+        logger.info("Prometheus Metrics Port: %s", self.prometheus_metrics_port)
+        logger.info("Prometheus Bind Address: %s", self.prometheus_bind_address)
+        logger.info("Gunicorn Workers: %s", self.gunicorn_workers)
+        logger.info("Gunicorn Timeout: %s", self.gunicorn_timeout)
+        logger.info("Gunicorn Keepalive: %s", self.gunicorn_keepalive)
+        logger.info("=" * 50)
 
 
 # Global configuration instance

--- a/src/gunicorn_prometheus_exporter/metrics.py
+++ b/src/gunicorn_prometheus_exporter/metrics.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 try:
     os.makedirs(config.prometheus_multiproc_dir, exist_ok=True)
 except Exception as e:
-    print(f"Warning: Failed to prepare PROMETHEUS_MULTIPROC_DIR: {e}")
+    logger.warning("Failed to prepare PROMETHEUS_MULTIPROC_DIR: %s", e)
 
 # Prometheus Registry - Don't create MultiProcessCollector here
 # It will be created in the gunicorn config when needed


### PR DESCRIPTION
## Summary
- use the existing logger instead of `print`
- log configuration issues and info details

## Testing
- `ruff format src/gunicorn_prometheus_exporter/metrics.py src/gunicorn_prometheus_exporter/config.py src/gunicorn_prometheus_exporter/__init__.py`
- `ruff check src/gunicorn_prometheus_exporter/metrics.py src/gunicorn_prometheus_exporter/config.py src/gunicorn_prometheus_exporter/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_6884caf8d620832b8aebc159553d3bec