### PR TITLE
Implement forwarder status tracking

### DIFF
--- a/src/gunicorn_prometheus_exporter/config.py
+++ b/src/gunicorn_prometheus_exporter/config.py
@@ -36,6 +36,7 @@ class ExporterConfig:
     ENV_REDIS_PASSWORD = "REDIS_PASSWORD"  # nosec - environment variable name
     ENV_REDIS_KEY_PREFIX = "REDIS_KEY_PREFIX"
     ENV_REDIS_FORWARD_INTERVAL = "REDIS_FORWARD_INTERVAL"
+    ENV_REDIS_COLLECT_INTERVAL = "REDIS_COLLECT_INTERVAL"
 
     # Cleanup environment variables
     ENV_CLEANUP_DB_FILES = "CLEANUP_DB_FILES"
@@ -47,9 +48,9 @@ class ExporterConfig:
     def _setup_multiproc_dir(self):
         """Set up the Prometheus multiprocess directory."""
         if not os.environ.get(self.ENV_PROMETHEUS_MULTIPROC_DIR):
-            os.environ[
-                self.ENV_PROMETHEUS_MULTIPROC_DIR
-            ] = self.PROMETHEUS_MULTIPROC_DIR
+            os.environ[self.ENV_PROMETHEUS_MULTIPROC_DIR] = (
+                self.PROMETHEUS_MULTIPROC_DIR
+            )
 
     @property
     def prometheus_multiproc_dir(self) -> str:
@@ -152,6 +153,11 @@ class ExporterConfig:
     def redis_forward_interval(self) -> int:
         """Get Redis forward interval in seconds."""
         return int(os.environ.get(self.ENV_REDIS_FORWARD_INTERVAL, "30"))
+
+    @property
+    def redis_collect_interval(self) -> int:
+        """Get Redis collect interval in seconds."""
+        return int(os.environ.get(self.ENV_REDIS_COLLECT_INTERVAL, "1"))
 
     @property
     def cleanup_db_files(self) -> bool:

--- a/src/gunicorn_prometheus_exporter/forwarder/manager.py
+++ b/src/gunicorn_prometheus_exporter/forwarder/manager.py
@@ -103,9 +103,28 @@ class ForwarderManager:
 
     def get_status(self) -> Dict[str, dict]:
         """Get status of all forwarders."""
-        return {
+        status = {
             name: forwarder.get_status() for name, forwarder in self._forwarders.items()
         }
+
+        running_count = 0
+        total_forwards = 0
+        last_forward_time = None
+        for forwarder in self._forwarders.values():
+            if forwarder.is_running():
+                running_count += 1
+            fwd_status = forwarder.get_status()
+            total_forwards += fwd_status.get("forward_count", 0)
+            ts = fwd_status.get("last_forward_time")
+            if ts is not None and (last_forward_time is None or ts > last_forward_time):
+                last_forward_time = ts
+
+        status.update(
+            running_count=running_count,
+            total_forwards=total_forwards,
+            last_forward_time=last_forward_time,
+        )
+        return status
 
     def get_running_forwarders(self) -> List[str]:
         """Get list of currently running forwarder names."""


### PR DESCRIPTION
## Summary
- track forward counts and last forward time in `BaseForwarder`
- expose aggregated statistics from `ForwarderManager.get_status`
- support `REDIS_COLLECT_INTERVAL` in config
- add tests for new functionality

## Testing
- `ruff format src tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_6884ca5fa9c8832b9a5e77564ecaa6de