### PR TITLE
Fix coverage generation location

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,8 @@ deps =
     gunicorn
     redis>=4.0.0
 commands =
-    pytest tests/ --cov=gunicorn_prometheus_exporter --cov-report=xml {posargs}
+    pytest tests/ --cov=gunicorn_prometheus_exporter \
+        --cov-report=xml:{toxinidir}/coverage.xml {posargs}
 
 [testenv:lint]
 description = Run linters and code quality tools


### PR DESCRIPTION
## Summary
- ensure `coverage.xml` is produced in the repository root

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*

------
https://chatgpt.com/codex/tasks/task_e_6884f686e43c832bb88a37ba47abc00e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to ensure coverage reports are saved in the project root directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->