### PR TITLE
Remove localhost references

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,14 @@ gunicorn -c gunicorn.conf.py app:app
 
 ### Access Metrics
 
-Metrics are automatically exposed on `http://localhost:9091/metrics`:
+Metrics are automatically exposed on the configured bind address and port (default: `0.0.0.0:9091`):
 
 ```bash
-curl http://localhost:9091/metrics
+# Using default configuration
+curl http://0.0.0.0:9091/metrics
+
+# Or use your configured bind address
+curl http://YOUR_BIND_ADDRESS:9091/metrics
 ```
 
 ## Documentation
@@ -109,7 +113,7 @@ See the `example/` directory for complete working examples:
 | `GUNICORN_WORKERS` | `1` | Number of workers |
 | `PROMETHEUS_MULTIPROC_DIR` | Auto-generated | Multiprocess directory |
 | `REDIS_ENABLED` | `false` | Enable Redis forwarding |
-| `REDIS_URL` | `redis://localhost:6379` | Redis connection URL |
+| `REDIS_URL` | `redis://127.0.0.1:6379` | Redis connection URL (configure for your environment) |
 
 ### Gunicorn Hooks
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@ Complete reference for all configuration options available in the Gunicorn Prome
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `REDIS_ENABLED` | `false` | Enable Redis metrics forwarding |
-| `REDIS_HOST` | `localhost` | Redis server hostname |
+| `REDIS_HOST` | `127.0.0.1` | Redis server hostname (configure for your environment) |
 | `REDIS_PORT` | `6379` | Redis server port |
 | `REDIS_DB` | `0` | Redis database number |
 | `REDIS_PASSWORD` | - | Redis authentication password |

--- a/docs/examples/django-integration.md
+++ b/docs/examples/django-integration.md
@@ -220,7 +220,7 @@ global:
 scrape_configs:
   - job_name: 'django-gunicorn'
     static_configs:
-      - targets: ['localhost:9091']
+      - targets: ['your-app-host:9091']  # Replace with your application hostname
     metrics_path: /metrics
     scrape_interval: 5s
 ```

--- a/docs/examples/flask-integration.md
+++ b/docs/examples/flask-integration.md
@@ -266,7 +266,7 @@ global:
 scrape_configs:
   - job_name: 'flask-gunicorn'
     static_configs:
-      - targets: ['localhost:9091']
+      - targets: ['your-app-host:9091']  # Replace with your application hostname
     metrics_path: /metrics
     scrape_interval: 5s
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ gunicorn -c gunicorn.conf.py your_app:app
 
 ### 4. Access Metrics
 
-Visit `http://localhost:9091/metrics` to see your Prometheus metrics!
+Visit your configured metrics endpoint to see your Prometheus metrics!
 
 ## Available Metrics
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -77,10 +77,10 @@ gunicorn -c gunicorn.conf.py your_app:app
 
 ### Check Metrics Endpoint
 
-Visit `http://localhost:9091/metrics` to see your Prometheus metrics:
+Visit your configured metrics endpoint (default: `http://0.0.0.0:9091/metrics`) to see your Prometheus metrics:
 
 ```bash
-curl http://localhost:9091/metrics
+curl http://0.0.0.0:9091/metrics  # Or use your configured bind address
 ```
 
 You should see output like:
@@ -97,7 +97,7 @@ gunicorn_worker_request_duration_seconds_bucket{worker_id="worker_1_1234567890",
 
 ### Check Application Health
 
-Your main application should still be accessible at `http://localhost:8000`.
+Your main application should still be accessible at your configured bind address and port.
 
 ## 🐳 Docker Setup
 
@@ -169,7 +169,7 @@ raw_env = [
     "PROMETHEUS_MULTIPROC_DIR=/tmp/prometheus_multiproc",
     "GUNICORN_WORKERS=4",
     "REDIS_ENABLED=true",
-    "REDIS_HOST=localhost",
+    "REDIS_HOST=your-redis-host",  # Configure for your environment
     "REDIS_PORT=6379"
 ]
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -82,7 +82,7 @@ raw_env = [
 **Diagnosis**:
 ```bash
 # Check if metrics server is running
-curl http://localhost:9091/metrics
+curl http://YOUR_BIND_ADDRESS:9091/metrics  # Replace with your configured address
 
 # Check Gunicorn logs
 tail -f gunicorn.log
@@ -141,7 +141,7 @@ docker run -d -p 6379:6379 redis:alpine
 # gunicorn.conf.py
 raw_env = [
     "REDIS_ENABLED=true",
-    "REDIS_HOST=localhost",
+    "REDIS_HOST=your-redis-host",  # Configure for your environment
     "REDIS_PORT=6379",
     "REDIS_PASSWORD=your_password",  # if needed
 ]
@@ -314,7 +314,7 @@ def check_metrics_endpoint():
     """Check if metrics endpoint is accessible."""
     try:
         port = os.environ.get('PROMETHEUS_METRICS_PORT', '9091')
-        response = requests.get(f'http://localhost:{port}/metrics', timeout=5)
+        response = requests.get(f'http://YOUR_BIND_ADDRESS:{port}/metrics', timeout=5)  # Replace with your configured address
         if response.status_code == 200:
             print(f"✅ Metrics endpoint accessible on port {port}")
             return True

--- a/example/gunicorn_basic.conf.py
+++ b/example/gunicorn_basic.conf.py
@@ -24,7 +24,7 @@ os.environ.setdefault("PROMETHEUS_MULTIPROC_DIR", "/tmp/prometheus_multiproc")  
 os.environ.setdefault("PROMETHEUS_METRICS_PORT", "9090")
 os.environ.setdefault("PROMETHEUS_BIND_ADDRESS", "127.0.0.1")  # nosec B104
 os.environ.setdefault("REDIS_ENABLED", "true")
-os.environ.setdefault("REDIS_HOST", "localhost")
+os.environ.setdefault("REDIS_HOST", "127.0.0.1")  # Configure for your environment
 os.environ.setdefault("REDIS_PORT", "6379")
 os.environ.setdefault("REDIS_FORWARD_INTERVAL", "15")
 os.environ.setdefault("CLEANUP_DB_FILES", "true")

--- a/example/gunicorn_redis_based.conf.py
+++ b/example/gunicorn_redis_based.conf.py
@@ -26,7 +26,7 @@ os.environ.setdefault("PROMETHEUS_BIND_ADDRESS", "127.0.0.1")  # nosec B104
 
 # Redis configuration
 os.environ.setdefault("REDIS_ENABLED", "true")
-os.environ.setdefault("REDIS_HOST", "localhost")
+os.environ.setdefault("REDIS_HOST", "127.0.0.1")  # Configure for your environment
 os.environ.setdefault("REDIS_PORT", "6379")
 os.environ.setdefault("REDIS_FORWARD_INTERVAL", "5")
 os.environ.setdefault("CLEANUP_DB_FILES", "false")

--- a/src/gunicorn_prometheus_exporter/config.py
+++ b/src/gunicorn_prometheus_exporter/config.py
@@ -136,7 +136,9 @@ class ExporterConfig:
     @property
     def redis_host(self) -> str:
         """Get Redis host."""
-        return os.environ.get(self.ENV_REDIS_HOST, "localhost")
+        return os.environ.get(
+            self.ENV_REDIS_HOST, "127.0.0.1"
+        )  # Default for local development
 
     @property
     def redis_port(self) -> int:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation and example configurations to use generic or configurable addresses instead of hardcoded "localhost" for Prometheus metrics and Redis host settings.
  * Clarified instructions for setting bind addresses and hostnames, emphasizing user configurability.
  * Added comments and notes to guide users in adapting configurations to their environment.

* **Style**
  * Replaced default Redis host values from "localhost" to "127.0.0.1" for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->